### PR TITLE
update dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@ Provided without any (implied) support nor warranty! (See [GPLv3 license](https:
 
 ## Requirements
 
-- At least Java 11
-- [Paper](https://papermc.io) Minecraft server software (tested on 1.16.5+, should be the same version on all synced servers)
+- At least Java 21
+- [Paper](https://papermc.io) Minecraft server software (tested on 1.20.6+, should be the same version on all synced
+  servers)
 - [redis](https://redis.io) pub-sub
 - [OpenInv](https://github.com/jikoo/OpenInv) (optionally, for a more smooth experience)
 
@@ -15,7 +16,7 @@ Provided without any (implied) support nor warranty! (See [GPLv3 license](https:
 1. Install redis, Paper, SyncInv (and optionally OpenInv).
 2. Configure the SyncInv [`config.yml`](https://github.com/Minebench/SyncInv/blob/master/src/main/resources/config.yml):
     1. Specify the `server-name` for each server as set in your proxy config
-    2. Setup the values for the pub-sub connection to your redis server in teh `redis` section
+    2. Setup the values for the pub-sub connection to your redis server in the `redis` section
     3. Toggle the types of data you want to sync in the `sync` section
     4. Familiarize yourself with all the [other settings](https://github.com/Minebench/SyncInv/blob/master/src/main/resources/config.yml) and adjust if necessary (the most important one probably beeing the `required-servers` list and the `server-group` name if you want multiple different sync groups in your network)
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>de.minebench</groupId>
     <artifactId>syncinv</artifactId>
-    <version>0.6.2-SNAPSHOT</version>
+    <version>0.6.3-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>SyncInv</name>
@@ -20,11 +20,7 @@
     <repositories>
         <repository>
             <id>papermc</id>
-            <url>https://papermc.io/repo/repository/maven-public/</url>
-        </repository>
-        <repository>
-            <id>minecraft-repo</id>
-            <url>https://libraries.minecraft.net/</url>
+            <url>https://repo.papermc.io/repository/maven-public/</url>
         </repository>
         <repository>
             <id>minebench-repo</id>
@@ -36,31 +32,31 @@
         <dependency>
             <groupId>io.papermc.paper</groupId>
             <artifactId>paper-api</artifactId>
-            <version>1.19.4-R0.1-SNAPSHOT</version>
+            <version>1.20.6-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.mojang</groupId>
             <artifactId>authlib</artifactId>
-            <version>1.5.25</version>
+            <version>6.0.54</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.26</version>
+            <version>1.18.32</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.lishid</groupId>
             <artifactId>openinvplugincore</artifactId>
-            <version>4.1.2-SNAPSHOT</version>
+            <version>4.4.4-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.lettuce</groupId>
             <artifactId>lettuce-core</artifactId>
-            <version>6.2.3.RELEASE</version>
+            <version>6.3.2.RELEASE</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>
@@ -97,18 +93,18 @@
         <defaultGoal>clean package</defaultGoal>
         <plugins>
             <plugin>
-                <version>3.10.1</version>
+                <version>3.13.0</version>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>11</source>
-                    <target>11</target>
+                    <source>21</source>
+                    <target>21</target>
                 </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.4.1</version>
+                <version>3.5.3</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
@@ -150,5 +146,4 @@
             </resource>
         </resources>
     </build>
-
 </project>

--- a/src/main/java/de/minebench/syncinv/messenger/ServerMessenger.java
+++ b/src/main/java/de/minebench/syncinv/messenger/ServerMessenger.java
@@ -245,11 +245,10 @@ public abstract class ServerMessenger {
                     } else if (plugin.getOpenInv() != null){
                         OfflinePlayer offlinePlayer = plugin.getServer().getOfflinePlayer(playerId);
                         if (offlinePlayer.hasPlayedBefore()) {
+                            // we can ensure here that openInv is using the same player instance as we do and therefor it is safe to unload regardless of openinv saving it or not
                             Player p = plugin.getOpenInv().loadPlayer(offlinePlayer);
                             if (p != null) {
-                                plugin.getOpenInv().retainPlayer(p, plugin);
                                 PlayerData data = plugin.getData(p);
-                                plugin.getOpenInv().releasePlayer(p, plugin);
                                 plugin.getOpenInv().unload(p);
                                 sendMessage(message.getSender(), MessageType.DATA, data);
                             } else {

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: ${project.name}
 version: '${minecraft.plugin.version}'
-api-version: '1.13'
+api-version: '1.20.6'
 main: de.minebench.syncinv.SyncInv
 softdepend: [OpenInv]
 authors: [Phoenix616]


### PR DESCRIPTION
Updated the dependencies to the newest (1.20.6) version.
Most importantly is OpenInv with a change in its public API, where "retainPlayer" is now marked for removal.

I know the way I aggressively pushed everything to the newest versions probably means loading this version on older Spigot/Paper versions doesn't work, but since there is version indifferent reflection, loading it in the api defined 1.13 could have been broken anyway.
