### PR TITLE
authlib 6.0.58

### DIFF
--- a/src/main/java/de/minebench/syncinv/SyncInv.java
+++ b/src/main/java/de/minebench/syncinv/SyncInv.java
@@ -194,14 +194,14 @@ public final class SyncInv extends JavaPlugin {
                 ? new File(getServer().getWorlds().get(0).getWorldFolder(), "playerdata")
                 : new File(new File(getServer().getWorlds().get(0).getWorldFolder(), "players"), "data");
 
-        MethodHandle tempHandle = null;
+        MethodHandle tempUUIDGetterHandle = null;
         try {
-            tempHandle = MethodHandles.privateLookupIn(GameProfile.class, MethodHandles.lookup()).findGetter(GameProfile.class, "id", UUID.class);
+            tempUUIDGetterHandle = MethodHandles.privateLookupIn(GameProfile.class, MethodHandles.lookup()).findGetter(GameProfile.class, "id", UUID.class);
         } catch (NoSuchFieldException | IllegalAccessException e) {
             getLogger().log(Level.SEVERE, "Could not get MethodHandle to access uuids from GameProfile. If anything happens, we will be unable to log the uuids!", e);
         }
         // java being java. We can't assign a final variable in a try block.
-        final MethodHandle finalHandle = tempHandle;
+        final MethodHandle uuidGetterHandle = tempUUIDGetterHandle;
 
         try {
             Method methodGetOfflinePlayer = getServer().getClass().getMethod("getOfflinePlayer", GameProfile.class);
@@ -209,9 +209,9 @@ public final class SyncInv extends JavaPlugin {
                 try {
                     return  (OfflinePlayer) methodGetOfflinePlayer.invoke(getServer(), gameProfile);
                 } catch (IllegalAccessException | InvocationTargetException e) {
-                    if (finalHandle != null) {
+                    if (uuidGetterHandle != null) {
                         try {
-                            logDebug("Could not create offline player for " + finalHandle.invoke(gameProfile) + "! " + e.getMessage());
+                            logDebug("Could not create offline player for " + uuidGetterHandle.invoke(gameProfile) + "! " + e.getMessage());
                         } catch (Throwable ex) {
                             logDebug("Could not create offline player. " + e.getMessage());
                             logDebug("And uuid lookup failed: " + ex.getMessage());
@@ -230,9 +230,9 @@ public final class SyncInv extends JavaPlugin {
                         Object nameAndId = nameAndIdConstructor.newInstance(gameProfile);
                         return  (OfflinePlayer) methodGetOfflinePlayer.invoke(getServer(), nameAndId);
                     } catch (IllegalAccessException | InvocationTargetException | InstantiationException e1) {
-                        if (finalHandle != null) {
+                        if (uuidGetterHandle != null) {
                             try {
-                                logDebug("Could not create offline player for " + finalHandle.invoke(gameProfile) + "! " + e.getMessage());
+                                logDebug("Could not create offline player for " + uuidGetterHandle.invoke(gameProfile) + "! " + e.getMessage());
                             } catch (Throwable e2) {
                                 logDebug("Could not create offline player. " + e.getMessage());
                                 logDebug("And uuid lookup failed: " + e2.getMessage());

--- a/src/main/java/de/minebench/syncinv/SyncInv.java
+++ b/src/main/java/de/minebench/syncinv/SyncInv.java
@@ -47,6 +47,8 @@ import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
@@ -191,13 +193,30 @@ public final class SyncInv extends JavaPlugin {
         playerDataFolder = getServer().getMinecraftVersion().startsWith("1.")
                 ? new File(getServer().getWorlds().get(0).getWorldFolder(), "playerdata")
                 : new File(new File(getServer().getWorlds().get(0).getWorldFolder(), "players"), "data");
+
+        MethodHandle tempHandle = null;
+        try {
+            tempHandle = MethodHandles.privateLookupIn(GameProfile.class, MethodHandles.lookup()).findGetter(GameProfile.class, "id", UUID.class);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            getLogger().log(Level.SEVERE, "Could not get MethodHandle to access uuids from GameProfile. If anything happens, we will be unable to log the uuids!", e);
+        }
+        // java being java. We can't assign a final variable in a try block.
+        final MethodHandle finalHandle = tempHandle;
+
         try {
             Method methodGetOfflinePlayer = getServer().getClass().getMethod("getOfflinePlayer", GameProfile.class);
             getOfflinePlayer = (gameProfile -> {
                 try {
                     return  (OfflinePlayer) methodGetOfflinePlayer.invoke(getServer(), gameProfile);
                 } catch (IllegalAccessException | InvocationTargetException e) {
-                    logDebug("Could not create offline player for " + gameProfile.getId() + "! " + e.getMessage());
+                    if (finalHandle != null) {
+                        try {
+                            logDebug("Could not create offline player for " + finalHandle.invoke(gameProfile) + "! " + e.getMessage());
+                        } catch (Throwable ex) {
+                            logDebug("Could not create offline player. " + e.getMessage());
+                            logDebug("And uuid lookup failed: " + ex.getMessage());
+                        }
+                    }
                 }
                 return null;
             });
@@ -211,7 +230,14 @@ public final class SyncInv extends JavaPlugin {
                         Object nameAndId = nameAndIdConstructor.newInstance(gameProfile);
                         return  (OfflinePlayer) methodGetOfflinePlayer.invoke(getServer(), nameAndId);
                     } catch (IllegalAccessException | InvocationTargetException | InstantiationException e1) {
-                        logDebug("Could not create offline player for " + gameProfile.getId() + "! " + e.getMessage());
+                        if (finalHandle != null) {
+                            try {
+                                logDebug("Could not create offline player for " + finalHandle.invoke(gameProfile) + "! " + e.getMessage());
+                            } catch (Throwable e2) {
+                                logDebug("Could not create offline player. " + e.getMessage());
+                                logDebug("And uuid lookup failed: " + e2.getMessage());
+                            }
+                        }
                     }
                     return null;
                 });


### PR DESCRIPTION
Minecraft updated authlib to version 6.0.58 in recent versions, changing how a GameProfile's uuid is getting accessed (it's a record now!). 
Added MethodHandle getter to the (potentially) private member to stay compatible between both versions.